### PR TITLE
Exclude non-functional tests from automatic runs

### DIFF
--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: backend
-        run: npm install
+        run: npm ci
 
       - name: Run Jest tests with coverage
         working-directory: backend

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    needs: deploy # ensure deploy job runs first
 
     steps:
       - name: Checkout code
@@ -28,7 +27,8 @@ jobs:
 
       - name: Run Jest tests with coverage
         working-directory: backend
-        run: npm run test:coverage
+        # don't run non-functional requirements tests automatically since may conflict with ec2 deploy
+        run: npm run test:coverage -- --testPathIgnorePatterns="(/non_functional_requirements/)"
         env:
           EDAMAM_APP_ID: ${{ secrets.EDAMAM_APP_ID }}
           EDAMAM_API_KEY: ${{ secrets.EDAMAM_API_KEY }}

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    needs: deploy # ensure deploy job runs first
 
     steps:
       - name: Checkout code
@@ -19,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: "18"
 
       - name: Install dependencies
         working-directory: backend

--- a/backend/__tests__/non_functional_requirements/performance.test.ts
+++ b/backend/__tests__/non_functional_requirements/performance.test.ts
@@ -1,6 +1,5 @@
 describe("Unmocked Performance test", () => {
   beforeAll(async () => {
-    jest.setTimeout(20000); //20s
     // sleep 2 seconds to allow proper setup
     await new Promise((resolve) => setTimeout(resolve, 2000));
   });


### PR DESCRIPTION
The non-functional tests are excluded because they may conflict with the EC2 deployment process, potentially making requests while the server is being re-deployed. Additionally, these tests make requests to the gateway, and since we have a limit on free requests, running them on every test cycle serves little purpose.