### PR TITLE
Filter recipes with allergies

### DIFF
--- a/backend/__tests__/no_mock/NoMockRecipe.test.ts
+++ b/backend/__tests__/no_mock/NoMockRecipe.test.ts
@@ -169,7 +169,7 @@ const SAMPLE_RECIPE = {
 
 // Interface POST /recipes
 describe("Unmocked: POST /recipes", () => {
-  // Input: string tripID of a route that has already been created and stored in route DB
+  // Input: string tripID of a route that has already been created and stored in route DB and userID
   // Expected status code: 201
   // Expected behavior: recipes are successfully generated and saved in db
   // Expected output: object with tripID and array of recipes objects. recipes contain recipeName,
@@ -220,7 +220,7 @@ describe("Unmocked: POST /recipes", () => {
     );
   });
 
-  // Input: missing body parameters
+  // Input: missing body parameters (tripID and userID)
   // Expected status code: 400
   // Expected behavior: database is unchanged
   // Expected output: error message indicating missing parameters
@@ -253,7 +253,7 @@ describe("Unmocked: POST /recipes", () => {
     expect(dbCountBefore).toBe(dbCountAfter);
   });
 
-  // Input: Malformed parameters (tripID is not an ObjectId)
+  // Input: Malformed parameter (tripID is not an ObjectId) and valid userID
   // Expected status code: 400
   // Expected behavior: database is unchanged
   // Expected output: error message indicating invalid tripID
@@ -283,7 +283,7 @@ describe("Unmocked: POST /recipes", () => {
     expect(dbCountBefore).toBe(dbCountAfter);
   });
 
-  // Input: tripID is not in the route database
+  // Input: tripID is not in the route database and valid userID
   // Expected status code: 404
   // Expected behavior: database is unchanged
   // Expected output: error message indicating route does not exist
@@ -313,7 +313,7 @@ describe("Unmocked: POST /recipes", () => {
     expect(dbCountBefore).toBe(dbCountAfter);
   });
 
-  // Input: tripID points to a route with no stops
+  // Input: tripID points to a route with no stops and valid userID
   // Expected status code: 500
   // Expected behavior: database is unchanged
   // Expected output: error message indicating internal issue

--- a/backend/__tests__/no_mock/NoMockRecipe.test.ts
+++ b/backend/__tests__/no_mock/NoMockRecipe.test.ts
@@ -178,7 +178,7 @@ describe("Unmocked: POST /recipes", () => {
     // setup: insert sample route into db
     const route_db = client.db(ROUTES_DB_NAME);
     const route_collection = route_db.collection<RouteDBEntry>(
-      ROUTES_COLLECTION_NAME
+      ROUTES_COLLECTION_NAME,
     );
     const route_result = await route_collection.insertOne(SAMPLE_ROUTE);
     const tripID = route_result.insertedId.toHexString();
@@ -186,6 +186,7 @@ describe("Unmocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID,
+        userID: "test-user",
       })
       .expect(201);
 
@@ -211,11 +212,11 @@ describe("Unmocked: POST /recipes", () => {
     expect(result?.recipes[1]).toHaveProperty("recipeID", 113);
     expect(result?.recipes[1]).toHaveProperty(
       "url",
-      "https://www.foodnetwork.com/recipes/biscotti-regina-3608012"
+      "https://www.foodnetwork.com/recipes/biscotti-regina-3608012",
     );
     expect(result?.recipes[1]).toHaveProperty(
       "ingredients",
-      SAMPLE_RECIPE.recipes[0].ingredients
+      SAMPLE_RECIPE.recipes[0].ingredients,
     );
   });
 
@@ -234,8 +235,13 @@ describe("Unmocked: POST /recipes", () => {
     // error should mention parameters missing
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("tripID")
-      )
+        error.msg.includes("tripID"),
+      ),
+    ).toBe(true);
+    expect(
+      response.body.errors.some((error: { msg: string }) =>
+        error.msg.includes("userID"),
+      ),
     ).toBe(true);
 
     // verify db unchaged
@@ -261,6 +267,7 @@ describe("Unmocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: "123", // tripID should be an ObjectId
+        userID: "test-user",
       })
       .expect(400);
 
@@ -290,6 +297,7 @@ describe("Unmocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: new ObjectId().toHexString(), // nonexistant tripID
+        userID: "test-user",
       })
       .expect(404);
 
@@ -313,7 +321,7 @@ describe("Unmocked: POST /recipes", () => {
     // insert route with no stops
     const route_db = client.db(ROUTES_DB_NAME);
     const route_collection = route_db.collection<RouteDBEntry>(
-      ROUTES_COLLECTION_NAME
+      ROUTES_COLLECTION_NAME,
     );
     const route_result = await route_collection.insertOne({
       userID: "test-user",
@@ -343,59 +351,7 @@ describe("Unmocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: route_result.insertedId.toHexString(),
-      })
-      .expect(500);
-
-    expect(response.body).toHaveProperty("error");
-    expect(response.body.error).toContain("Internal server error");
-
-    // verfify db unchaged
-    const dbCountAfter = await client
-      .db(RECIPE_DB_NAME)
-      .collection(RECIPE_COLLECTION_NAME)
-      .countDocuments();
-
-    expect(dbCountBefore).toBe(dbCountAfter);
-  });
-
-  // Input: tripID points to a route with no stops
-  // Expected status code: 500
-  // Expected behavior: database is unchanged
-  // Expected output: error message indicating internal issue
-  test("Malformed route with no stops", async () => {
-    // insert route with no stops
-    const route_db = client.db(ROUTES_DB_NAME);
-    const route_collection = route_db.collection<RouteDBEntry>(
-      ROUTES_COLLECTION_NAME
-    );
-    const route_result = await route_collection.insertOne({
-      userID: "test-user",
-      route: {
-        start_location: {
-          name: "Vancouver",
-          latitude: 49.2608724,
-          longitude: -123.113952,
-          population: 631486,
-        },
-        end_location: {
-          name: "Toronto",
-          latitude: 43.6534817,
-          longitude: -79.3839347,
-          population: 2731571,
-        },
-        stops: [],
-      },
-    });
-
-    const dbCountBefore = await client
-      .db(RECIPE_DB_NAME)
-      .collection<RecipeDBEntry>(RECIPE_COLLECTION_NAME)
-      .countDocuments();
-
-    const response = await request(app)
-      .post("/recipes")
-      .send({
-        tripID: route_result.insertedId.toHexString(),
+        userID: "test-user",
       })
       .expect(500);
 
@@ -432,19 +388,19 @@ describe("Unmocked: GET /recipes/:id", () => {
     expect(response.body).toHaveLength(1);
     expect(response.body[0]).toHaveProperty(
       "recipeName",
-      SAMPLE_RECIPE.recipes[0].recipeName
+      SAMPLE_RECIPE.recipes[0].recipeName,
     );
     expect(response.body[0]).toHaveProperty(
       "recipeID",
-      SAMPLE_RECIPE.recipes[0].recipeID
+      SAMPLE_RECIPE.recipes[0].recipeID,
     );
     expect(response.body[0]).toHaveProperty(
       "url",
-      SAMPLE_RECIPE.recipes[0].url
+      SAMPLE_RECIPE.recipes[0].url,
     );
     expect(response.body[0]).toHaveProperty(
       "ingredients",
-      SAMPLE_RECIPE.recipes[0].ingredients
+      SAMPLE_RECIPE.recipes[0].ingredients,
     );
     expect(response.body).toEqual(SAMPLE_RECIPE.recipes);
 
@@ -479,7 +435,7 @@ describe("Unmocked: GET /recipes/:id", () => {
     const response = await request(app).get(`/recipes/${tripID}`).expect(404);
     expect(response.body).toHaveProperty(
       "error",
-      "No recipes found for tripID"
+      "No recipes found for tripID",
     );
   });
 });
@@ -558,14 +514,14 @@ describe("Unmocked: DELETE /recipes/:id", () => {
     // setup: insert sample route
     const route_db = client.db(ROUTES_DB_NAME);
     const route_collection = route_db.collection<RouteDBEntry>(
-      ROUTES_COLLECTION_NAME
+      ROUTES_COLLECTION_NAME,
     );
     const route_result = await route_collection.insertOne(SAMPLE_ROUTE);
     const tripID = route_result.insertedId.toHexString();
 
     const recipe_db = client.db(RECIPE_DB_NAME);
     const recipe_collection = recipe_db.collection<RecipeDBEntry>(
-      RECIPE_COLLECTION_NAME
+      RECIPE_COLLECTION_NAME,
     );
     const originalCount = await recipe_collection.countDocuments();
 
@@ -574,7 +530,7 @@ describe("Unmocked: DELETE /recipes/:id", () => {
       .expect(404);
     expect(response.body).toHaveProperty(
       "error",
-      "No recipes found for tripID"
+      "No recipes found for tripID",
     );
 
     // check db to make sure nothing was deleted
@@ -599,7 +555,7 @@ describe("Unmocked: DELETE /recipes/:id", () => {
       .expect(404);
     expect(response.body).toHaveProperty(
       "error",
-      "No recipes found for tripID"
+      "No recipes found for tripID",
     );
 
     // check nothing in db

--- a/backend/__tests__/no_mock/NoMockRoute.test.ts
+++ b/backend/__tests__/no_mock/NoMockRoute.test.ts
@@ -64,8 +64,8 @@ describe("Unmocked: POST /routes", () => {
       .send({
         userID: "test-user",
         origin: "Vancouver",
-        destination: "Toronto",
-        numStops: 1,
+        destination: "Nanaimo",
+        numStops: 6,
       })
       .expect(201);
 
@@ -74,7 +74,7 @@ describe("Unmocked: POST /routes", () => {
     expect(response.body).toHaveProperty("start_location");
     expect(response.body).toHaveProperty("end_location");
     expect(Array.isArray(response.body.stops)).toBe(true);
-    expect(response.body.stops).toHaveLength(1); // 1 stop
+    expect(response.body.stops).toHaveLength(6); // 6 stops
 
     // db verification
     const db = client.db(ROUTES_DB_NAME);
@@ -85,9 +85,9 @@ describe("Unmocked: POST /routes", () => {
     expect(result).not.toBeNull();
     expect(result).toHaveProperty("userID", "test-user");
     expect(result?.route.start_location).toHaveProperty("name", "Vancouver");
-    expect(result?.route.end_location).toHaveProperty("name", "Toronto");
+    expect(result?.route.end_location).toHaveProperty("name", "Nanaimo");
     expect(Array.isArray(result?.route.stops)).toBe(true);
-    expect(result?.route.stops).toHaveLength(1); // 1 stop
+    expect(result?.route.stops).toHaveLength(6); // 6 stops
 
     // db cleanup happens in afterEach in jest.setup.ts
   });
@@ -106,23 +106,23 @@ describe("Unmocked: POST /routes", () => {
     // error should mention parameters missing
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("userID")
-      )
+        error.msg.includes("userID"),
+      ),
     ).toBe(true);
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("origin")
-      )
+        error.msg.includes("origin"),
+      ),
     ).toBe(true);
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("destination")
-      )
+        error.msg.includes("destination"),
+      ),
     ).toBe(true);
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("numStops")
-      )
+        error.msg.includes("numStops"),
+      ),
     ).toBe(true);
 
     // verify db unchaged
@@ -221,8 +221,8 @@ describe("Unmocked: POST /routes", () => {
     expect(response.body).toHaveProperty("errors");
     expect(
       response.body.errors.some((error: { msg: string }) =>
-        error.msg.includes("must be an integer")
-      )
+        error.msg.includes("must be an integer"),
+      ),
     ).toBe(true);
 
     // verify db unchaged
@@ -256,7 +256,7 @@ describe("Unmocked: POST /routes", () => {
 
     expect(response.body).toHaveProperty("error");
     expect(response.body.error).toContain(
-      "Number of stops must be between 1 and 10"
+      "Number of stops must be between 1 and 10",
     );
 
     // verify db unchaged
@@ -290,7 +290,7 @@ describe("Unmocked: POST /routes", () => {
 
     expect(response.body).toHaveProperty("error");
     expect(response.body.error).toContain(
-      "Number of stops must be between 1 and 10"
+      "Number of stops must be between 1 and 10",
     );
 
     // verify db unchaged
@@ -324,7 +324,7 @@ describe("Unmocked: POST /routes", () => {
 
     expect(response.body).toHaveProperty("error");
     expect(response.body.error).toContain(
-      "Origin and destination cannot be the same"
+      "Origin and destination cannot be the same",
     );
 
     // verify db unchaged
@@ -357,11 +357,11 @@ describe("Unmocked: GET /routes/:id", () => {
 
     expect(response.body).toHaveProperty(
       "start_location",
-      SAMPLE_ROUTE.start_location
+      SAMPLE_ROUTE.start_location,
     );
     expect(response.body).toHaveProperty(
       "end_location",
-      SAMPLE_ROUTE.end_location
+      SAMPLE_ROUTE.end_location,
     );
     expect(response.body).toHaveProperty("stops", SAMPLE_ROUTE.stops);
 

--- a/backend/__tests__/with_mock/WithMockRecipe.test.ts
+++ b/backend/__tests__/with_mock/WithMockRecipe.test.ts
@@ -1,9 +1,10 @@
 import request from "supertest";
 import app from "../../index";
 import * as RecipeHelper from "../../helpers/RecipeHelper";
+import * as RouteHelper from "../../helpers/RouteHelpers";
 import { Recipe, RecipeDBEntry } from "../../interfaces/RecipeInterfaces";
 import { client } from "../../services";
-import { Db, MongoClient, ObjectId } from "mongodb";
+import { ObjectId } from "mongodb";
 import { RouteDBEntry } from "../../interfaces/RouteInterfaces";
 
 jest.mock("node-fetch", () => jest.fn());
@@ -319,8 +320,12 @@ const MOCK_ROUTE_NO_STOPS: RouteDBEntry = {
 
 // Interface POST /recipes
 describe("Mocked: POST /recipes", () => {
+  // Mocked behavior: mock valid route returned from db
   beforeEach(() => {
     jest.clearAllMocks();
+    jest
+      .spyOn(RouteHelper, "getRouteFromDb")
+      .mockResolvedValue(MOCK_ROUTE.route);
   });
 
   afterEach(() => {
@@ -328,7 +333,7 @@ describe("Mocked: POST /recipes", () => {
   });
 
   // Mocked behavior: mock edamam api call that does not get received and mock route in db
-  // Input: valid tripID
+  // Input: valid tripID and userID
   // Expected status code: 500
   // Expected behavior: error handled gracefully
   // Expected output: error message
@@ -346,6 +351,7 @@ describe("Mocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: result.insertedId.toHexString(),
+        userID: "test-user",
       })
       .expect(500);
 
@@ -353,7 +359,7 @@ describe("Mocked: POST /recipes", () => {
   });
 
   // Mocked behavior: mock edamam api call to return 503 status response and mock route in db
-  // Input: valid tripID
+  // Input: valid tripID and userID
   // Expected status code: 500
   // Expected behavior: error handled gracefully
   // Expected output: error message
@@ -375,6 +381,7 @@ describe("Mocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: route_response.insertedId.toHexString(),
+        userID: "test-user",
       })
       .expect(500);
 
@@ -383,7 +390,7 @@ describe("Mocked: POST /recipes", () => {
 
   // Mocked behavior: RecipeHelper.saveRecipesToDb throws an error and RecipeHelper.createRecipesfromRoute
   //                  returns a valid recipe
-  // Input: tripID valid
+  // Input: tripID and userID valid
   // Expected status code: 500
   // Expected behavior: error handled gracefully
   // Expected output: error message
@@ -406,16 +413,18 @@ describe("Mocked: POST /recipes", () => {
       .post("/recipes")
       .send({
         tripID: new ObjectId().toHexString(),
+        userID: "test-user",
       })
       .expect(500);
 
     expect(response.body).toHaveProperty("error", "Internal server error");
+    expect(RouteHelper.getRouteFromDb).toHaveBeenCalled();
     expect(RecipeHelper.createRecipesfromRoute).toHaveBeenCalled();
     expect(RecipeHelper.saveRecipesToDb).toHaveBeenCalled();
   });
 
   // Mocked behavior: RecipeHelper.createRecipesfromRoute has an empty implementation
-  // Input: invalid tripID
+  // Input: invalid tripID and valid userID
   // Expected status code: 400
   // Expected behavior: createRecipesfromRoute not called
   // Expected output: error message for invalid tripID format
@@ -424,19 +433,21 @@ describe("Mocked: POST /recipes", () => {
 
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: "invalidObjectId" }); // invalid ObjectId format
+      .send({ tripID: "invalidObjectId", userID: "test-user" }); // invalid ObjectId format
 
     expect(response.status).toBe(400);
     expect(response.body.error).toBe("Invalid tripID format");
     expect(RecipeHelper.createRecipesfromRoute).not.toHaveBeenCalled();
   });
 
-  /// Mocked behavior: RecipeHelper.saveRecipesToDb has an empty implementation
-  // Input: valid tripID and route with no stops in db
+  // Mocked behavior: RecipeHelper.saveRecipesToDb has an empty implementation and route with
+  //                  no stops in in-memory db
+  // Input: valid tripID and userID
   // Expected status code: 500
   // Expected behavior: saveRecipesToDb not called
   // Expected output: error message
   test("No stops found in route", async () => {
+    jest.restoreAllMocks(); // clear mock from beforeEach
     jest.spyOn(RecipeHelper, "saveRecipesToDb").mockImplementation();
 
     const result = await client
@@ -446,15 +457,15 @@ describe("Mocked: POST /recipes", () => {
 
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: result.insertedId.toHexString() })
+      .send({ tripID: result.insertedId.toHexString(), userID: "test-user" })
       .expect(500);
 
     expect(response.body).toHaveProperty("error", "Internal server error");
     expect(RecipeHelper.saveRecipesToDb).not.toHaveBeenCalled();
   });
 
-  // Mocked behavior: missing API key and db returns a valid route
-  // Input: valid tripID
+  // Mocked behavior: missing API key and app id
+  // Input: valid tripID and userID
   // Expected status code: 500
   // Expected behavior: error handled gracefully
   // Expected output: error message
@@ -464,31 +475,19 @@ describe("Mocked: POST /recipes", () => {
     delete process.env.EDAMAM_APP_ID;
     delete process.env.EDAMAM_API_KEY;
 
-    // mock db to return a valid route
-    const mockCollection = {
-      findOne: jest.fn().mockResolvedValue(MOCK_ROUTE),
-    };
-    const mockDb = {
-      collection: jest.fn().mockReturnValue(mockCollection),
-      databaseName: "route_data",
-    } as unknown as Db;
-    jest.spyOn(MongoClient.prototype, "db").mockReturnValue(mockDb);
-
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: new ObjectId().toHexString() })
+      .send({ tripID: new ObjectId().toHexString(), userID: "test-user" })
       .expect(500);
 
     expect(response.body).toHaveProperty("error", "Internal server error");
-    expect(MongoClient.prototype.db).toHaveBeenCalled();
 
     process.env.EDAMAM_API_KEY = originalApiKey;
     process.env.EDAMAM_APP_ID = originalAppId;
   });
 
   // Mocked behavior: fetch response with valid recipe but missing label and uri
-  //                  and db returns a valid route
-  // Input: valid tripID
+  // Input: valid tripID and userID
   // Expected status code: 201
   // Expected behavior: recipe added to database
   // Expected output: recipe with empty recipeName and uri
@@ -512,20 +511,9 @@ describe("Mocked: POST /recipes", () => {
         }),
     });
 
-    // mock db to return a valid route
-    const mockCollection = {
-      findOne: jest.fn().mockResolvedValue(MOCK_ROUTE),
-      insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
-    };
-    const mockDb = {
-      collection: jest.fn().mockReturnValue(mockCollection),
-      databaseName: "route_data",
-    } as unknown as Db;
-    jest.spyOn(MongoClient.prototype, "db").mockReturnValue(mockDb);
-
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: new ObjectId().toHexString() })
+      .send({ tripID: new ObjectId().toHexString(), userID: "test-user" })
       .expect(201);
 
     // verify the returned recipe has empty recipeName and recipeID = 0
@@ -537,7 +525,6 @@ describe("Mocked: POST /recipes", () => {
         ingredients: SAMPLE_RECIPE.ingredients,
       }),
     );
-    expect(MongoClient.prototype.db).toHaveBeenCalled();
   });
 
   // Mocked behavior: RecipeHelper.saveRecipesToDb has an empty implementation
@@ -546,11 +533,12 @@ describe("Mocked: POST /recipes", () => {
   // Expected behavior: saveRecipesToDb not called
   // Expected output: error message
   test("No route for tripID", async () => {
+    jest.restoreAllMocks(); // clear mock from beforeEach
     jest.spyOn(RecipeHelper, "saveRecipesToDb").mockImplementation();
 
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: new ObjectId().toHexString() }) // nonexistant tripID
+      .send({ tripID: new ObjectId().toHexString(), userID: "test-user" }) // nonexistant tripID
       .expect(404);
 
     expect(response.body).toHaveProperty("error", "Trip not found");
@@ -559,7 +547,7 @@ describe("Mocked: POST /recipes", () => {
 
   // Mocked behavior: RecipeHelper.createRecipesfromRoute returns a valid recipe list
   //                  and in-mem db contains a valid route
-  // Input: valid tripID
+  // Input: valid tripID and userID
   // Expected status code: 201
   // Expected behavior: createRecipesfromRoute called
   // Expected output: list of recipes
@@ -575,7 +563,7 @@ describe("Mocked: POST /recipes", () => {
 
     const response = await request(app)
       .post("/recipes")
-      .send({ tripID: result.insertedId.toHexString() })
+      .send({ tripID: result.insertedId.toHexString(), userID: "test-user" })
       .expect(201);
 
     expect(RecipeHelper.createRecipesfromRoute).toHaveBeenCalled();

--- a/backend/controllers/RecipeController.ts
+++ b/backend/controllers/RecipeController.ts
@@ -28,10 +28,8 @@ export const createRecipes = async (
       return res.status(404).json({ error: "Trip not found" });
     }
 
+    // allergies are optional
     const allergies = await getAllergiesFromDb(userID);
-    if (!allergies) {
-      return res.status(404).json({ error: "User not found" });
-    }
 
     const recipes = await createRecipesfromRoute(
       route,

--- a/backend/controllers/RecipeController.ts
+++ b/backend/controllers/RecipeController.ts
@@ -6,6 +6,8 @@ import {
   deleteRecipesFromDb,
 } from "../helpers/RecipeHelper";
 import { ObjectId } from "mongodb";
+import { getRouteFromDb } from "../helpers/RouteHelpers";
+import { getAllergiesFromDb } from "../helpers/PreferenceHelper";
 
 // generate a list of recipes from a route
 // POST /recipes
@@ -16,14 +18,29 @@ export const createRecipes = async (
 ) => {
   try {
     // validation of params performed by express-validator middleware
-    const { tripID } = req.body as { tripID: string };
+    const { tripID, userID } = req.body as { tripID: string; userID: string };
     if (!ObjectId.isValid(tripID)) {
       return res.status(400).json({ error: "Invalid tripID format" });
     }
 
-    const recipes = await createRecipesfromRoute(tripID);
-    if (!recipes) {
+    const route = await getRouteFromDb(tripID);
+    if (!route) {
       return res.status(404).json({ error: "Trip not found" });
+    }
+
+    const allergies = await getAllergiesFromDb(userID);
+    if (!allergies) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const recipes = await createRecipesfromRoute(
+      route,
+      allergies.map((allergyObj) => allergyObj.allergy),
+    );
+    if (!recipes) {
+      return res
+        .status(404)
+        .json({ error: "Could not find recipes that match user preferences" });
     }
 
     // save recipes to db

--- a/backend/helpers/RecipeHelper.ts
+++ b/backend/helpers/RecipeHelper.ts
@@ -76,7 +76,7 @@ export async function createRecipesfromRoute(
       }
 
       // no recipes found that match user's preferences
-      if (!recipe) {
+      if (recipe.length === 0) {
         return null;
       }
 

--- a/backend/helpers/RecipeHelper.ts
+++ b/backend/helpers/RecipeHelper.ts
@@ -70,7 +70,7 @@ export async function createRecipesfromRoute(
       for (const allergy of allergies) {
         recipe = recipe.filter((r) => {
           return !r.ingredients.some((ingredient) =>
-            ingredient.food.match(new RegExp(allergy, "i")),
+            ingredient.food.toLowerCase().includes(allergy.toLowerCase()),
           );
         });
       }

--- a/backend/routes/RecipesRoutes.ts
+++ b/backend/routes/RecipesRoutes.ts
@@ -1,5 +1,9 @@
 import { body } from "express-validator";
-import { createRecipes, deleteRecipes, getRecipes } from "../controllers/RecipeController";
+import {
+  createRecipes,
+  deleteRecipes,
+  getRecipes,
+} from "../controllers/RecipeController";
 
 export const RecipeRoutes = [
   {
@@ -11,6 +15,10 @@ export const RecipeRoutes = [
         .exists()
         .isString()
         .withMessage("tripID is required and must be a string"),
+      body("userID")
+        .exists()
+        .isString()
+        .withMessage("userID is required and must be a string"),
     ],
   },
   {


### PR DESCRIPTION
- Updated recipe endpoints to choose recipes based on user allergies
- `POST /recipes` now takes 2 body parameters: tripID and userID (instead of just tripID)
- Added mocked and unmocked tests for new functionality